### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
-<h1 align="center">SpecBridge</h1>
-An MCP server that turns OpenAPI specifications into MCP tools. Scan a folder for OpenAPI spec files and automatically generate corresponding tools. No configuration files, no separate servers - just drop specs in a folder and get tools.
-
-Built with [FastMCP](https://www.npmjs.com/package/fastmcp) for TypeScript.
-
+<h1 align="center">SpecBridge
+<p>
 <a href="https://glama.ai/mcp/servers/@TBosak/specbridge">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@TBosak/specbridge/badge" alt="Specbridge MCP server" />
 </a>
+</p>
+</h1>
+
+An MCP server that turns OpenAPI specifications into MCP tools. Scan a folder for OpenAPI spec files and automatically generate corresponding tools. No configuration files, no separate servers - just drop specs in a folder and get tools.
+
+
+Built with [FastMCP](https://www.npmjs.com/package/fastmcp) for TypeScript.
 
 ## ✨ Features
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ An MCP server that turns OpenAPI specifications into MCP tools. Scan a folder fo
 
 Built with [FastMCP](https://www.npmjs.com/package/fastmcp) for TypeScript.
 
+<a href="https://glama.ai/mcp/servers/@TBosak/specbridge">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@TBosak/specbridge/badge" alt="Specbridge MCP server" />
+</a>
+
 ## ✨ Features
 
 - 🎯 **Zero Configuration**: Filesystem is the interface - just drop OpenAPI specs in a folder


### PR DESCRIPTION
This PR adds a badge for the [Specbridge](https://glama.ai/mcp/servers/@TBosak/specbridge) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@TBosak/specbridge">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@TBosak/specbridge/badge" alt="Specbridge MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.